### PR TITLE
Improve persistence and layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # DiabeTech MVP
 
-Web app básica para registro y visualización de datos de diabetes usando Flask.
+Aplicación web sencilla para registrar y visualizar datos relacionados con la diabetes. Utiliza Flask y almacena la información en un archivo `data.json`.
+
+## Uso
+
+1. Instala las dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Ejecuta la aplicación:
+   ```bash
+   python app.py
+   ```
+   Puedes definir `PORT`, `FLASK_DEBUG` y `SECRET_KEY` en el entorno si lo necesitas.
+
+Los registros se guardarán en `data.json` y se mostrarán en el panel principal.
+

--- a/data.json
+++ b/data.json
@@ -1,0 +1,2 @@
+{"glucosa": ["105 mg/dL"], "comidas": ["Desayuno: Avena y fruta"], "entrenos": ["Caminata 30 min"]}
+

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,31 @@
+body {
+    font-family: sans-serif;
+    padding: 20px;
+}
+header h1 {
+    margin: 0 0 20px;
+}
+.flash {
+    list-style: none;
+    padding: 0;
+    margin-bottom: 10px;
+    color: green;
+}
+input, select, button {
+    display: block;
+    margin: 10px 0;
+    width: 100%;
+    padding: 10px;
+}
+.panel {
+    margin-top: 30px;
+}
+ul {
+    background: #f0f0f0;
+    padding: 10px;
+}
+@media (max-width: 600px) {
+    body {
+        font-size: 18px;
+    }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}DiabeTech{% endblock %}</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <header>
+        <h1>DiabeTech</h1>
+        {% with messages = get_flashed_messages() %}
+            {% if messages %}
+                <ul class="flash">
+                {% for msg in messages %}<li>{{ msg }}</li>{% endfor %}
+                </ul>
+            {% endif %}
+        {% endwith %}
+    </header>
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,36 +1,25 @@
-<!DOCTYPE html>
-<html lang="es">
-<head>
-    <meta charset="UTF-8">
-    <title>Dashboard DiabeTech</title>
-</head>
-<body>
-    <h1>Dashboard de Registro de Diabetes</h1>
-
-    <form action="/submit" method="post">
-        <label for="glucose">Nivel de glucosa:</label>
-        <input type="number" id="glucose" name="glucose" required><br><br>
-
-        <label for="insulin">Nivel de insulina:</label>
-        <input type="number" id="insulin" name="insulin" required><br><br>
-
-        <label for="datetime">Fecha y hora:</label>
-        <input type="datetime-local" id="datetime" name="datetime" required><br><br>
-
+{% extends "base.html" %}
+{% block title %}Panel DiabeTech{% endblock %}
+{% block content %}
+    <form method="POST" action="{{ url_for('registro') }}">
+        <label for="tipo">Tipo:</label>
+        <select name="tipo" id="tipo">
+            <option value="glucosa">Glucosa</option>
+            <option value="comidas">Comida</option>
+            <option value="entrenos">Entreno</option>
+        </select>
+        <input name="valor" placeholder="Valor o descripción" required />
         <button type="submit">Registrar</button>
     </form>
-
-    <hr>
-
-    <h2>Datos registrados</h2>
-    {% if data %}
+    <div class="panel">
+        <h2>Últimos registros</h2>
+        {% for key, items in data.items() %}
+        <h3>{{ key|capitalize }}:</h3>
         <ul>
-        {% for key, value in data.items() %}
-            <li><strong>{{ key }}:</strong> {{ value }}</li>
-        {% endfor %}
+            {% for item in items %}
+            <li>{{ item }}</li>
+            {% endfor %}
         </ul>
-    {% else %}
-        <p>No hay datos registrados aún.</p>
-    {% endif %}
-</body>
-</html>
+        {% endfor %}
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add basic JSON datastore with helpers
- flash success messages and use `url_for`
- new base template and updated dashboard
- expanded README with usage instructions
- add initial data.json

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_684254789fd083268b304612fd524a90